### PR TITLE
Fix: Use of uninitialized value $word

### DIFF
--- a/XKPasswd.pm
+++ b/XKPasswd.pm
@@ -2322,7 +2322,7 @@ sub _substitute_characters{
     }
     
     # If we got here, go ahead and apply the substitutions
-    foreach my $i (0..(scalar @{$words_ref})){
+    foreach my $i (0..((scalar @{$words_ref}) - 1)){
         my $word = $words_ref->[$i];
         foreach my $char (keys %{$self->{_CONFIG}->{character_substitutions}}){
             my $sub = $self->{_CONFIG}->{character_substitutions}->{$char};


### PR DESCRIPTION
fix related to this issue:
https://github.com/bbusschots/xkpasswd.pm/issues/1

Updated iterator to reduce the upper bound by 1.  This results in
correct behavior.
