### PR TITLE
Add subtitution_probability

### DIFF
--- a/bin/hsxkpasswd
+++ b/bin/hsxkpasswd
@@ -227,6 +227,9 @@ GetOptions(
             $cmd_args{rcdata} = load_rcfile($val);
         }
     },
+    'show-entropy|e' => sub{
+        $cmd_args{show_entropy} = 1;
+    },
     'verbose' => \$verbose,
     'warn|w=s' => sub{
         my ($opt_name, $val) = @_;
@@ -459,6 +462,13 @@ if($verbose){
 
 # genereate and print the passwords
 say join "\n", $hsxkpwd_obj->passwords($num_pwds);
+my %pwdstats=$hsxkpwd_obj->stats;
+if ($cmd_args{show_entropy}) {
+    say "-------------------------------------------------------";
+    printf "Entropy blind: %d(min), %d(max); Entropy seen: %d\n",
+        $pwdstats{password_entropy_blind_min}, $pwdstats{password_entropy_blind_max},
+        $pwdstats{password_entropy_seen};
+}
 
 #
 # === Helper Functions ========================================================#
@@ -637,6 +647,7 @@ Available Options:
     -p|--preset PRESET_NAME
     -r|--rng-pkg PERL_PACKAGE_NAME
     --rng-pkg-args JSON_STRING
+    -e|--show-entropy
     
 Information/Utility Functions:
 
@@ -764,6 +775,10 @@ available on the system.
 A JSON string representing an array of arguments to pass to the constructor of
 the package specified with B<-r>/B<--rng-pkg>.
 
+=item B<-w>, B<--show-entropy>
+
+If present, display a line containing information about the amount of entropy
+in the passwords generated at the bottom of the list of passwords.
 
 =item B<-w>, B<--warn>
 

--- a/lib/Crypt/HSXKPasswd.pm
+++ b/lib/Crypt/HSXKPasswd.pm
@@ -2782,7 +2782,7 @@ This module uses words to make up the bulk of the passwords it generates, but
 it also adds carefully placed symbols and digits to add security without making
 the passwords difficult to remember, read, type, and speak.
 
-In shot, this module is for people who prefer passwords that look like this:
+In short, this module is for people who prefer passwords that look like this:
 
     !15.play.MAJOR.fresh.FLAT.23!
 
@@ -2987,7 +2987,7 @@ in the second scenario the seen entropy.
 The blind entropy is solely determined by the configuration settings, the seen
 entropy depends on both the settings and the dictionary file used.
 
-Calculating the bind entropy C<Eb> is quite straightforward, we just need to
+Calculating the blind entropy C<Eb> is quite straightforward, we just need to
 know the size of the alphabet resulting from the configuration C<A>, and the
 minimum length of passwords generated with the configuration C<L>, and plug
 those values into this formula:

--- a/lib/Crypt/HSXKPasswd.pm
+++ b/lib/Crypt/HSXKPasswd.pm
@@ -2213,16 +2213,16 @@ sub _substitute_characters{
     foreach my $i (0..((scalar @{$words_ref}) - 1)){
         my $word = $words_ref->[$i];
         my $prob = $self->{_CONFIG}->{substitution_mode} // 'ALWAYS';
-	if ($prob ne 'NEVER') {
-	    foreach my $char (keys %{$self->{_CONFIG}->{character_substitutions}}){
-		my $sub = $self->{_CONFIG}->{character_substitutions}->{$char};
-		if ($prob eq 'RANDOM') {
-		    next if $self->_random_int(100) >= 50;
-		}
-		$word =~ s/$char/$sub/sxg;
-	    }
-	    $words_ref->[$i] = $word;
-	}
+        if ($prob ne 'NEVER') {
+            foreach my $char (keys %{$self->{_CONFIG}->{character_substitutions}}){
+                my $sub = $self->{_CONFIG}->{character_substitutions}->{$char};
+                if ($prob eq 'RANDOM') {
+                    next if $self->_random_int(100) >= 50;
+                }
+                $word =~ s/$char/$sub/sxg;
+            }
+            $words_ref->[$i] = $word;
+        }
     }
     
     # always return 1 to keep PerlCritic happy
@@ -2449,9 +2449,9 @@ sub _calculate_entropy_stats{
     # multiply in possible substituted characters
     if ($self->{_CONFIG}->{substitution_mode} && $self->{_CONFIG}->{substitution_mode} eq 'RANDOM' && $self->{_CONFIG}->{character_substitutions}) {
         for my $n (1..$self->{_CONFIG}->{num_words}){
-	    for my $m (1..scalar keys %{$self->{_CONFIG}->{character_substitutions}}) {
-		$b_seen_perms->bmul(Math::BigInt->new(2));
-	    }
+            for my $m (1..scalar keys %{$self->{_CONFIG}->{character_substitutions}}) {
+                $b_seen_perms->bmul(Math::BigInt->new(2));
+            }
         }
     }
     $ans{permutations_seen} = $b_seen_perms;

--- a/lib/Crypt/HSXKPasswd.pm
+++ b/lib/Crypt/HSXKPasswd.pm
@@ -2212,8 +2212,12 @@ sub _substitute_characters{
     # If we got here, go ahead and apply the substitutions
     foreach my $i (0..((scalar @{$words_ref}) - 1)){
         my $word = $words_ref->[$i];
+        my $prob = $self->{_CONFIG}->{substitution_probability} || 100;
         foreach my $char (keys %{$self->{_CONFIG}->{character_substitutions}}){
             my $sub = $self->{_CONFIG}->{character_substitutions}->{$char};
+            if ($prob > 0 && $prob < 100) {
+                next if $self->_random_int(100) >= $prob;
+            }
             $word =~ s/$char/$sub/sxg;
         }
         $words_ref->[$i] = $word;
@@ -2439,6 +2443,12 @@ sub _calculate_entropy_stats{
     while($num_padding_digits > 0){
         $b_seen_perms->bmul(Math::BigInt->new('10'));
         $num_padding_digits--;
+    }
+    # multiply in possible substituted characters
+    if ($self->{_CONFIG}->{substitution_probability} && $self->{_CONFIG}->{substitution_probability} > 0 && $self->{_CONFIG}->{substitution_probability} < 100) {
+        for my $n (1..$self->{_CONFIG}->{num_words}){
+            $b_seen_perms->bmul(Math::BigInt->new(2));
+        }
     }
     $ans{permutations_seen} = $b_seen_perms;
     _debug('got permutations_seen='.$ans{permutations_seen});

--- a/lib/Crypt/HSXKPasswd.pm
+++ b/lib/Crypt/HSXKPasswd.pm
@@ -2445,9 +2445,11 @@ sub _calculate_entropy_stats{
         $num_padding_digits--;
     }
     # multiply in possible substituted characters
-    if ($self->{_CONFIG}->{substitution_probability} && $self->{_CONFIG}->{substitution_probability} > 0 && $self->{_CONFIG}->{substitution_probability} < 100) {
+    if ($self->{_CONFIG}->{substitution_probability} && $self->{_CONFIG}->{substitution_probability} > 0 && $self->{_CONFIG}->{substitution_probability} < 100 && $self->{_CONFIG}->{character_substitutions}) {
         for my $n (1..$self->{_CONFIG}->{num_words}){
-            $b_seen_perms->bmul(Math::BigInt->new(2));
+	    for my $m (1..scalar @{$self->{_CONFIG}->{character_substitutions}}) {
+		$b_seen_perms->bmul(Math::BigInt->new(2));
+	    }
         }
     }
     $ans{permutations_seen} = $b_seen_perms;

--- a/lib/Crypt/HSXKPasswd/Types.pm
+++ b/lib/Crypt/HSXKPasswd/Types.pm
@@ -450,14 +450,17 @@ $_KEYS->{character_substitutions}->{type} = Type::Tiny->new(
         return _config_key_message($_, 'character_substitutions', $_KEYS->{character_substitutions}->{expects});
     },
 );
-$_KEYS->{substitution_probability}->{type} = Type::Tiny->new(
-    type => Type::Tiny->new(
-    parent => $POSITIVE_INTEGER,
+$_KEYS->{substitution_mode} = {
+    required => 0,
+    expects => q{one of the values 'ALWAYS', NEVER, or 'RANDOM'},
+};
+$_KEYS->{substitution_mode}->{type} = Type::Tiny->new(
+    parent => Enum[qw( ALWAYS NEVER RANDOM )],
     message => sub {
-        return _config_key_message($_, 'substitution_probability', $POSITIVE_INTEGER_ENGLISH);
-        }
-    ),
+        return _config_key_message($_, 'substitution_mode', $_KEYS->{substitution_mode}->{expects});
+    }
 );
+
 
 # add a type for config key names
 my $CONFIG_KEY_NAME_ENGLISH = 'for a list of all defined config key names see the docs, or the output from the function Crypt::HSXKPasswd->defined_config_keys()';

--- a/lib/Crypt/HSXKPasswd/Types.pm
+++ b/lib/Crypt/HSXKPasswd/Types.pm
@@ -450,6 +450,14 @@ $_KEYS->{character_substitutions}->{type} = Type::Tiny->new(
         return _config_key_message($_, 'character_substitutions', $_KEYS->{character_substitutions}->{expects});
     },
 );
+$_KEYS->{substitution_probability}->{type} = Type::Tiny->new(
+    type => Type::Tiny->new(
+    parent => $POSITIVE_INTEGER,
+    message => sub {
+        return _config_key_message($_, 'substitution_probability', $POSITIVE_INTEGER_ENGLISH);
+        }
+    ),
+);
 
 # add a type for config key names
 my $CONFIG_KEY_NAME_ENGLISH = 'for a list of all defined config key names see the docs, or the output from the function Crypt::HSXKPasswd->defined_config_keys()';


### PR DESCRIPTION
Added a new configuration option, "substitution_probability".
Gives percent chance that each word will have any given substitution
(from the character_substitutions) applied to it.

Also computes (maybe inaccurately?) the additional bits of entropy provided: for each word, for each substitution, it might be applied or not.  This does not account for the possibility that a given word might not have the letter to be substituted, though.

Does it really make sense to have this as a "probability" instead of just 50-50 random?  i.e. maybe something like substitution_application=>"RANDOM" (as opposed to "ALWAYS" let's say), instead of this?