### PR TITLE
Multisubs

### DIFF
--- a/lib/Crypt/HSXKPasswd.pm
+++ b/lib/Crypt/HSXKPasswd.pm
@@ -2213,16 +2213,16 @@ sub _substitute_characters{
     foreach my $i (0..((scalar @{$words_ref}) - 1)){
         my $word = $words_ref->[$i];
         my $prob = $self->{_CONFIG}->{substitution_mode} // 'ALWAYS';
-	if ($prob ne 'NEVER') {
-	    foreach my $char (keys %{$self->{_CONFIG}->{character_substitutions}}){
-		my $sub = $self->{_CONFIG}->{character_substitutions}->{$char};
-		if ($prob eq 'RANDOM') {
-		    next if $self->_random_int(100) >= 50;
-		}
-		$word =~ s/$char/$sub/sxg;
-	    }
-	    $words_ref->[$i] = $word;
-	}
+        if ($prob ne 'NEVER') {
+            foreach my $char (keys %{$self->{_CONFIG}->{character_substitutions}}){
+                my $sub = $self->{_CONFIG}->{character_substitutions}->{$char};
+                if ($prob eq 'RANDOM') {
+                    next if $self->_random_int(100) >= 50;
+                }
+                $word =~ s/$char/$sub/sxg;
+            }
+            $words_ref->[$i] = $word;
+        }
     }
     
     # always return 1 to keep PerlCritic happy
@@ -2449,9 +2449,9 @@ sub _calculate_entropy_stats{
     # multiply in possible substituted characters
     if ($self->{_CONFIG}->{substitution_mode} && $self->{_CONFIG}->{substitution_mode} eq 'RANDOM' && $self->{_CONFIG}->{character_substitutions}) {
         for my $n (1..$self->{_CONFIG}->{num_words}){
-	    for my $m (1..scalar keys %{$self->{_CONFIG}->{character_substitutions}}) {
-		$b_seen_perms->bmul(Math::BigInt->new(2));
-	    }
+            for my $m (1..scalar keys %{$self->{_CONFIG}->{character_substitutions}}) {
+                $b_seen_perms->bmul(Math::BigInt->new(2));
+            }
         }
     }
     $ans{permutations_seen} = $b_seen_perms;

--- a/lib/Crypt/HSXKPasswd.pm
+++ b/lib/Crypt/HSXKPasswd.pm
@@ -2466,7 +2466,7 @@ sub _calculate_entropy_stats{
         $num_padding_digits--;
     }
     # multiply in possible substituted characters
-    if ($self->{_CONFIG}->{character_substitutions} && $self->{_CONFIG}->{substitution_mode} ne 'NEVER') {
+    if ($self->{_CONFIG}->{character_substitutions} && ($self->{_CONFIG}->{substitution_mode} // 'ALWAYS') ne 'NEVER') {
         for my $n (1..$self->{_CONFIG}->{num_words}){
             for my $m (keys %{$self->{_CONFIG}->{character_substitutions}}) {
                 my $sb=$self->{_CONFIG}->{character_substitutions}->{$m};

--- a/lib/Crypt/HSXKPasswd.pm
+++ b/lib/Crypt/HSXKPasswd.pm
@@ -1007,9 +1007,19 @@ sub config_stats{
         if(defined $config->{character_substitutions}){
             CHAR_SUB:
             foreach my $char (keys %{$config->{character_substitutions}}){
-                if(length $config->{character_substitutions}->{$char} > 1){
-                    _warn('maximum length may be underestimated. The loaded config contains at least one character substitution which replaces a single character with multiple characters.');
-                    last CHAR_SUB;
+                if (ref $config->{character_substitutions}->{$char} eq 'ARRAY') {
+                    foreach my $sub (@{$config->{character_substitutions}->{$char}}) {
+                        if (length $sub > 1) {
+                            _warn('maximum length may be underestimated. The loaded config contains at least one character substitution which replaces a single character with multiple characters.');
+                            last CHAR_SUB;
+                        }
+                    }
+                }
+                else {
+                    if(length $config->{character_substitutions}->{$char} > 1){
+                        _warn('maximum length may be underestimated. The loaded config contains at least one character substitution which replaces a single character with multiple characters.');
+                        last CHAR_SUB;
+                    }
                 }
             }
         }
@@ -2216,6 +2226,15 @@ sub _substitute_characters{
         if ($prob ne 'NEVER') {
             foreach my $char (keys %{$self->{_CONFIG}->{character_substitutions}}){
                 my $sub = $self->{_CONFIG}->{character_substitutions}->{$char};
+                if (ref $sub eq 'ARRAY') {
+                    my $n = $self->_random_int($#$sub+2);
+                    if ($n > $#$sub) {
+                        $sub = $char;
+                    }
+                    else {
+                        $sub = $$sub[$n]
+                    }
+                }
                 if ($prob eq 'RANDOM') {
                     next if $self->_random_int(100) >= 50;
                 }
@@ -2447,10 +2466,18 @@ sub _calculate_entropy_stats{
         $num_padding_digits--;
     }
     # multiply in possible substituted characters
-    if ($self->{_CONFIG}->{substitution_mode} && $self->{_CONFIG}->{substitution_mode} eq 'RANDOM' && $self->{_CONFIG}->{character_substitutions}) {
+    if ($self->{_CONFIG}->{character_substitutions}) {
         for my $n (1..$self->{_CONFIG}->{num_words}){
-            for my $m (1..scalar keys %{$self->{_CONFIG}->{character_substitutions}}) {
-                $b_seen_perms->bmul(Math::BigInt->new(2));
+            for my $m (keys %{$self->{_CONFIG}->{character_substitutions}}) {
+                my $sb=$self->{_CONFIG}->{character_substitutions}->{$m};
+                if (ref $sb eq 'ARRAY') {
+                    $b_seen_perms->bmul(Math::BigInt->new($#$sb+2));
+                }
+                else {
+                    if ($self->{_CONFIG}->{substitution_mode} && $self->{_CONFIG}->{substitution_mode} eq 'RANDOM') {
+                        $b_seen_perms->bmul(Math::BigInt->new(2));
+                    }
+                }
             }
         }
     }
@@ -3440,6 +3467,11 @@ single letters. The substitutions can contain multiple characters. Specifying
 one or more substitutions with a length greater than one could lead to
 passwords being longer than expected, and to entropy calculations being under
 estimated. The module will issue a warning when such a config is loaded.
+
+A character substitution can also specify an I<array> as the substitution
+instead of a string.  In this case, an element is randomly chosen from the
+members of the array I<plus the original character> (i.e. no substitution
+at all) to be the substitution.
 
 =item *
 

--- a/lib/Crypt/HSXKPasswd.pm
+++ b/lib/Crypt/HSXKPasswd.pm
@@ -2212,8 +2212,12 @@ sub _substitute_characters{
     # If we got here, go ahead and apply the substitutions
     foreach my $i (0..((scalar @{$words_ref}) - 1)){
         my $word = $words_ref->[$i];
+        my $prob = $self->{_CONFIG}->{substitution_probability} || 100;
         foreach my $char (keys %{$self->{_CONFIG}->{character_substitutions}}){
             my $sub = $self->{_CONFIG}->{character_substitutions}->{$char};
+            if ($prob > 0 && $prob < 100) {
+                next if $self->_random_int(100) >= $prob;
+            }
             $word =~ s/$char/$sub/sxg;
         }
         $words_ref->[$i] = $word;
@@ -2439,6 +2443,12 @@ sub _calculate_entropy_stats{
     while($num_padding_digits > 0){
         $b_seen_perms->bmul(Math::BigInt->new('10'));
         $num_padding_digits--;
+    }
+    # multiply in possible substituted characters
+    if ($self->{_CONFIG}->{substitution_probability} && $self->{_CONFIG}->{substitution_probability} > 0 && $self->{_CONFIG}->{substitution_probability} < 100) {
+        for my $n (1..$self->{_CONFIG}->{num_words}){
+            $b_seen_perms->bmul(Math::BigInt->new(2));
+        }
     }
     $ans{permutations_seen} = $b_seen_perms;
     _debug('got permutations_seen='.$ans{permutations_seen});

--- a/lib/Crypt/HSXKPasswd.pm
+++ b/lib/Crypt/HSXKPasswd.pm
@@ -2466,7 +2466,7 @@ sub _calculate_entropy_stats{
         $num_padding_digits--;
     }
     # multiply in possible substituted characters
-    if ($self->{_CONFIG}->{character_substitutions}) {
+    if ($self->{_CONFIG}->{character_substitutions} && $self->{_CONFIG}->{substitution_mode} ne 'NEVER') {
         for my $n (1..$self->{_CONFIG}->{num_words}){
             for my $m (keys %{$self->{_CONFIG}->{character_substitutions}}) {
                 my $sb=$self->{_CONFIG}->{character_substitutions}->{$m};

--- a/lib/Crypt/HSXKPasswd.pm
+++ b/lib/Crypt/HSXKPasswd.pm
@@ -2445,9 +2445,11 @@ sub _calculate_entropy_stats{
         $num_padding_digits--;
     }
     # multiply in possible substituted characters
-    if ($self->{_CONFIG}->{substitution_probability} && $self->{_CONFIG}->{substitution_probability} > 0 && $self->{_CONFIG}->{substitution_probability} < 100) {
+    if ($self->{_CONFIG}->{substitution_probability} && $self->{_CONFIG}->{substitution_probability} > 0 && $self->{_CONFIG}->{substitution_probability} < 100 && $self->{_CONFIG}->{character_substitutions}) {
         for my $n (1..$self->{_CONFIG}->{num_words}){
-            $b_seen_perms->bmul(Math::BigInt->new(2));
+	    for my $m (1..scalar @{$self->{_CONFIG}->{character_substitutions}}) {
+		$b_seen_perms->bmul(Math::BigInt->new(2));
+	    }
         }
     }
     $ans{permutations_seen} = $b_seen_perms;

--- a/lib/Crypt/HSXKPasswd/Types.pm
+++ b/lib/Crypt/HSXKPasswd/Types.pm
@@ -445,7 +445,7 @@ $_KEYS->{character_substitutions} = {
     expects => 'a reference to a hash mapping zero or more Letters to their replacements which must be strings',
 };
 $_KEYS->{character_substitutions}->{type} = Type::Tiny->new(
-    parent => Map[$LETTER, Str],
+    parent => Map[$LETTER, Defined],
     message => sub {
         return _config_key_message($_, 'character_substitutions', $_KEYS->{character_substitutions}->{expects});
     },

--- a/lib/Crypt/HSXKPasswd/Types.pm
+++ b/lib/Crypt/HSXKPasswd/Types.pm
@@ -450,14 +450,17 @@ $_KEYS->{character_substitutions}->{type} = Type::Tiny->new(
         return _config_key_message($_, 'character_substitutions', $_KEYS->{character_substitutions}->{expects});
     },
 );
-$_KEYS->{substitution_probability}->{type} = Type::Tiny->new(
-    type => Type::Tiny->new(
-    parent => $POSITIVE_INTEGER,
+$_KEYS->{substitution_mode} = {
+    required => 0,
+    expects => q{one of the values 'ALWAYS', NEVER, or 'RANDOM'},
+};
+$_KEYS->{substitution_mode}->{type} = Type::Tiny->new(
+    parent => Enum[qw( ALWAYS NEVER RANDOM )],
     message => sub {
-        return _config_key_message($_, 'substitution_probability', $POSITIVE_INTEGER_ENGLISH);
-        }
-    ),
+        return _config_key_message($_, 'substitution_mode', $_KEYS->{substitution_mode}->{expects});
+    }
 );
+
 
 # add a type for config key names
 my $CONFIG_KEY_NAME_ENGLISH = 'for a list of all defined config key names see the docs, or the output from the function Crypt::HSXKPasswd->defined_config_keys()';

--- a/lib/Crypt/HSXKPasswd/Types.pm
+++ b/lib/Crypt/HSXKPasswd/Types.pm
@@ -450,6 +450,14 @@ $_KEYS->{character_substitutions}->{type} = Type::Tiny->new(
         return _config_key_message($_, 'character_substitutions', $_KEYS->{character_substitutions}->{expects});
     },
 );
+$_KEYS->{substitution_probability}->{type} = Type::Tiny->new(
+    type => Type::Tiny->new(
+    parent => $POSITIVE_INTEGER,
+    message => sub {
+        return _config_key_message($_, 'substitution_probability', $POSITIVE_INTEGER_ENGLISH);
+        }
+    ),
+);
 
 # add a type for config key names
 my $CONFIG_KEY_NAME_ENGLISH = 'for a list of all defined config key names see the docs, or the output from the function Crypt::HSXKPasswd->defined_config_keys()';


### PR DESCRIPTION
I coded that suggestion you made: if you use an *array* instead of a string as the value in the character_substitutions array, it will pick one of those characters—OR the original, unchanged one—to be the substitute, the choice being made individually for each word.  I put in some description in the POD that I hope isn't too confusing.

I had to relax the restriction in Types.pm to allow it to be a map to "Any"; is there a way to restrict it to Strings or Arrays?

Not sure I did this pull request right; it includes commits that are part of other pull requests too.  Probably if you merge them in the right order it will all work out.