### PR TITLE
Fix type check for args passed to add_words()

### DIFF
--- a/lib/Crypt/HSXKPasswd/Dictionary/Basic.pm
+++ b/lib/Crypt/HSXKPasswd/Dictionary/Basic.pm
@@ -216,7 +216,7 @@ sub add_words{
     # validate args
     state $args_check = multisig(
         [NonEmptyString, Optional[Maybe[NonEmptyString]]],
-        [ArrayRef[Str]], Optional[Item],
+        [ArrayRef[Str], Optional[Item]],
     );
     my ($dict_source, $encoding) = $args_check->(@args);
     


### PR DESCRIPTION
@tobyink and @perlpunk worked out in
https://rt.cpan.org/Public/Bug/Display.html?id=144672 that the closing square brace in the types check to the `add_words` sub was not in the correct place.  As mentioned by @tobyink in the RT ticket:

> Versions of Type::Params prior to 2.000000 would not have spotted this mistake

@perlpunk provided the patch which I'm submitting in this commit.

This change makes the test suite pass again and would hence close both issue #42 and issue #38.

This PR is submitted in the hope that it is useful. If you need anything changed, please don't hesitate to let me know and I'll be more than happy to update and resubmit as necessary.