### PR TITLE
Fix minor typo in _increment_random_cache() error message

### DIFF
--- a/lib/Crypt/HSXKPasswd.pm
+++ b/lib/Crypt/HSXKPasswd.pm
@@ -2007,7 +2007,7 @@ sub _increment_random_cache{
     }
     foreach my $num (@random_numbers){
         unless($num =~ m/^1|(0([.]\d+)?)$/sx){
-            _error("random function returned and invalid value ($num)");
+            _error("random function returned an invalid value ($num)");
         }
     }
     


### PR DESCRIPTION
While looking at some log output on a production system at $work, we had this error case be triggered and I happened to notice a typo: the word "and" should have been just "an".  This is fixed in this commit.

This PR is submitted in the hope that it is useful. If you want me to change anything, please just let me know and I'll be more than happy to update and resubmit as necessary.